### PR TITLE
TLにトゥートがない場合は続きを読み込まない

### DIFF
--- a/app/js/tl/tl.js
+++ b/app/js/tl/tl.js
@@ -306,7 +306,7 @@ function moreload(type, tlid) {
 		var data=obj[tlid].data;
 	}
 	var sid = $("#timeline_" + tlid + " .cvo").last().attr("unique-id");
-	if (localStorage.getItem("morelock") != sid) {
+	if (sid && localStorage.getItem("morelock") != sid) {
 		localStorage.setItem("morelock", sid);
 		if (type == "mix" && localStorage.getItem("domain_" + acct_id)!="misskey.xyz") {
 			mixmore(tlid,"integrated");


### PR DESCRIPTION
TLにトゥートがない場合、 `/api/v1/timelines/direct?max_id=undefined` のようなリクエストが送られるので修正しました。
特に新規登録直後のDMがない人の場合に発生しやすいです。