### PR TITLE
Fix duplicate listener for iTunes NowPlaying

### DIFF
--- a/app/js/ui/spotify.js
+++ b/app/js/ui/spotify.js
@@ -124,7 +124,7 @@ function nowplaying(mode){
         var electron = require("electron");
 	    var ipc = electron.ipcRenderer;
 	    ipc.send('itunes', "");
-	    ipc.on('itunes-np', function (event, arg) {
+	    ipc.once('itunes-np', function (event, arg) {
             console.log(arg);
             var content=localStorage.getItem("np-temp");
             if(!content || content=="" || content=="null"){


### PR DESCRIPTION
iTunesのNowPlayingでイベントリスナが残ったままになって増え続けることがあるので修正