### PR TITLE
Fix NowPlaying template for macOS

### DIFF
--- a/app/js/ui/spotify.js
+++ b/app/js/ui/spotify.js
@@ -151,11 +151,11 @@ function nowplaying(mode){
             var regExp = new RegExp("{composer}", "g");
             content = content.replace(regExp, arg.composer);
             var regExp = new RegExp("{hz}", "g");
+            content = content.replace(regExp, arg.sampleRate/1000+"kHz");
             var regExp = new RegExp("{lyricist}", "g");
             content = content.replace(regExp, "");
             var regExp = new RegExp("{bpm}", "g");
             content = content.replace(regExp, "");
-            content = content.replace(regExp, arg.sampleRate/1000+"kHz");
             var regExp = new RegExp("{bitRate}", "g");
             content = content.replace(regExp, arg.bitRate+"kbps");
             var regExp = new RegExp("{genre}", "g");


### PR DESCRIPTION
`{hz}`がサンプルレートに変換されず残ったままトゥートに入れられるので修正