### PR TITLE
Fix cannot reopen in macOS

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -1,4 +1,4 @@
-'use strict';
+
 var dir='file://' + __dirname;
 var base=dir + '/view/';
 // Electronのモジュール
@@ -68,6 +68,12 @@ app.on('window-all-closed', function() {
 	if (process.platform != 'darwin') {
 		electron.session.defaultSession.clearCache(() => {})
 		app.quit();
+	}
+});
+// macOSでウィンドウを閉じた後に再度開けるようにする
+app.on('activate', function() {
+	if (mainWindow == null) {
+		createWindow();
 	}
 });
 

--- a/app/main.js
+++ b/app/main.js
@@ -115,6 +115,7 @@ function createWindow() {
 	}
 	// ウィンドウが閉じられたらアプリも終了
 	mainWindow.on('closed', function() {
+		electron.ipcMain.removeAllListeners();
 		mainWindow = null;
 	});
 	mainWindow.on('close', function() {


### PR DESCRIPTION
macOSでTheDeskのウィンドウを閉じた後に、Dockに残っているにも関わらず開き直すことが出来ない問題を修正	