### PR TITLE
Fix nowplaying for asar packed

### DIFF
--- a/app/js/ui/spotify.js
+++ b/app/js/ui/spotify.js
@@ -129,6 +129,10 @@ function nowplaying(mode){
 
 	    ipc.send('itunes', "");
 	    ipc.once('itunes-np', function (event, arg) {
+            if (arg.cmd) {
+              console.error(arg);
+              return;
+            }
             console.log(arg);
             var content=localStorage.getItem("np-temp");
             if(!content || content=="" || content=="null"){

--- a/app/js/ui/spotify.js
+++ b/app/js/ui/spotify.js
@@ -142,8 +142,8 @@ function nowplaying(mode){
                     media(arg.path,"image/png","new");
                 }
             }else if(platform=="darwin"){
-                if(flag && arg.artworks[0]){
-                    ipc.send('bmp-image', [arg.artworks[0].path,0]);
+                if(flag && arg.existsArtwork){
+                    media(arg.artworks[0].data,"image/png","new");
                 }
             }
             var regExp = new RegExp("{song}", "g");

--- a/app/main/np.js
+++ b/app/main/np.js
@@ -29,8 +29,9 @@ function np(mainWindow){
             nowplaying.getRawData().then(function (value) {
                 mainWindow.webContents.send('itunes-np', value);
             }).catch(function (error) {
-                // 非同期処理失敗。呼ばれない
-                console.log(error);
+                // エラーを返す
+                console.error(error);
+                mainWindow.webContents.send('itunes-np', error);
             });
             }else{
                 var {NowPlaying,PlayerName} = require("nowplaying-node");

--- a/app/main/np.js
+++ b/app/main/np.js
@@ -4,7 +4,7 @@ function np(mainWindow){
     const app = electron.app;
     const fs = require("fs");
     var ipc = electron.ipcMain;
-    ipc.on('itunes', (e, args) => {
+    ipc.on('itunes', async (e, args) => {
         //Verified on Windows
         console.log("Access");
         if(args[0]=="set"){
@@ -25,14 +25,15 @@ function np(mainWindow){
             var platform=process.platform;
             var bit=process.arch;
             if(platform=="darwin"){
-            const nowplaying = require("itunes-nowplaying-mac")
-            nowplaying.getRawData().then(function (value) {
+              try {
+                const nowplaying = require("itunes-nowplaying-mac");
+                const value = await nowplaying.getRawData();
                 mainWindow.webContents.send('itunes-np', value);
-            }).catch(function (error) {
+              } catch (error) {
                 // エラーを返す
                 console.error(error);
                 mainWindow.webContents.send('itunes-np', error);
-            });
+              }
             }else{
                 var {NowPlaying,PlayerName} = require("nowplaying-node");
                 var nppath=join(app.getPath("userData"), "nowplaying");

--- a/app/package.json
+++ b/app/package.json
@@ -54,6 +54,9 @@
   "build": {
     "productName": "TheDesk",
     "appId": "top.thedesk",
+    "asarUnpack": [
+      "node_modules/itunes-nowplaying-mac"
+    ],
     "directories": {
       "output": "../build"
     },

--- a/app/package.json
+++ b/app/package.json
@@ -48,7 +48,7 @@
   },
   "optionalDependencies": {
     "nowplaying-node": "^0.1.3",
-    "itunes-nowplaying-mac": "git+https://github.com/rinsuki/itunes-nowplaying-mac#pull/1/head",
+    "itunes-nowplaying-mac": "git+https://github.com/rinsuki/itunes-nowplaying-mac#pull/4/head",
     "font-manager": "^0.3.0"
   },
   "build": {


### PR DESCRIPTION
Fixed #44

18.2.1以降、asar圧縮するようになったことでmacOS版でiTunes NowPlayingが使えなくなった問題を修正します

itunes-nowplaying-macのPull Requestを変更したので #44 の問題についても解決されます