### PR TITLE
Fix poll vote button

### DIFF
--- a/app/js/lang/lang.en.js
+++ b/app/js/lang/lang.en.js
@@ -189,7 +189,7 @@ var lang={
     "lang_parse_clientmute":"muted",
     "lang_parse_mute":" will be muted. You can remove on preferences.",
     "lang_parse_voted":"Voted",
-    "lang_parse_vote":"Voted",
+    "lang_parse_vote":"Vote",
     "lang_parse_unvoted":"Show the result without voting",
     "lang_parse_endedvote":"Expired",
     "lang_parse_thread":"Show thread",

--- a/app/js/tl/parse.js
+++ b/app/js/tl/parse.js
@@ -489,7 +489,7 @@ function parse(obj, mix, acct_id, tlid, popup, mutefilter, type) {
 				var myvote=lang.lang_parse_voted;
 				var result_hide="";
 			}else{
-				myvote='<a onclick="voteMastodon(\''+acct_id+'\',\''+toot.poll.id+'\')" class="votebtn">'+lang.lang_parse_vote+'</a><br>';
+				var myvote='<a onclick="voteMastodon(\''+acct_id+'\',\''+toot.poll.id+'\')" class="votebtn">'+lang.lang_parse_vote+'</a><br>';
 				if(choices[0].votes_count===0 || choices[0].votes_count>0){
 					myvote=myvote+'<a onclick="showResult(\''+acct_id+'\',\''+toot.poll.id+'\')" class="pointer">'+lang.lang_parse_unvoted+"</a>";
 				}
@@ -798,8 +798,8 @@ function parse(obj, mix, acct_id, tlid, popup, mutefilter, type) {
 			'</div></div>' +
 			'<div class="area-toot">'+tickerdom+'<span class="' +
 			api_spoil + ' cw_text_' + toot.id + '"><span class="cw_text">' + spoil + "</span>" + spoiler_show +
-			'</span><span class="toot ' + spoiler + '">' + content +poll+
-			'</span>' +
+			'</span><span class="toot ' + spoiler + '">' + content +
+			'</span>' + poll +
 			'' + viewer + '' +
 			'</div><div class="area-additional"><span class="additional">' + analyze +
 			'</span>' +


### PR DESCRIPTION
投票ボタンが表示されないのでそれを修正します

`.toot` の中から出して `function additional(acct_id, tlid)` でボタンを削除させないようにします
この変更で Mastodon 2.8 の WebUI のように CW で隠されなくなります。これに問題がある場合は `additional(acct_id, tlid)` で `a.votebtn` `a.pointer` を無視するように修正する形を考えています

英語ロケールの投票ボタンを Voted から Vote へ修正