### PR TITLE
Fix integrated tl reconnect streaming

### DIFF
--- a/app/js/tl/mix.js
+++ b/app/js/tl/mix.js
@@ -94,12 +94,14 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 	websocketLocal[wslid] = new WebSocket(startLocal);
 	websocketHome[wshid].onopen = function(mess) {
 		localStorage.setItem("wssH_" + tlid, wshid);
-		console.log("Connect Streaming API(Integrated:Home)");
+		console.log(tlid + ":Connect Streaming API(Integrated:Home)");
+		console.log(mess);
 		$("#notice_icon_" + tlid).removeClass("red-text");
 	}
 	websocketLocal[wslid].onopen = function(mess) {
 		localStorage.setItem("wssL_" + tlid, wslid);
-		console.log("Connect Streaming API(Integrated:Local)");
+		console.log(tlid + ":Connect Streaming API(Integrated:Local)");
+		console.log(mess);
 		$("#notice_icon_" + tlid).removeClass("red-text");
 	}
 	websocketLocal[wslid].onmessage = function(mess) {
@@ -195,7 +197,8 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 		}
 	}
 	websocketLocal[wslid].onerror = function(error) {
-		console.error('WebSocket Error ' + error);
+		console.error('WebSocketLocal Error')
+		console.error(error);
 		if(mode=="error"){
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Error ' + error);
@@ -208,7 +211,7 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 		}
 	};
 	websocketLocal[wslid].onclose = function() {
-		console.error('WebSocketLocal Closing by error:' + tlid);
+		console.log('WebSocketLocal Closing:' + tlid);
 		if(mode=="error"){
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Closed');
@@ -221,7 +224,8 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 		}
 	};
 	websocketHome[wshid].onerror = function(error) {
-		console.error('WebSocket Error ' + error);
+		console.error('WebSocketHome Error')
+		console.error(error);
 		if(mode=="error"){
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Error ' + error);
@@ -234,7 +238,7 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 		}
 	};
 	websocketHome[wshid].onclose = function() {
-		console.error('WebSocketHome Closing by error:' + tlid);
+		console.log('WebSocketHome Closing:' + tlid);
 		if(mode=="error"){
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Closed');

--- a/app/js/tl/mix.js
+++ b/app/js/tl/mix.js
@@ -200,7 +200,11 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Error ' + error);
 		}else{
-			reconnector(tlid,TLtype,acct_id,"","error");
+			var errorct=localStorage.getItem("wserror_" + tlid)*1+1;
+			localStorage.setItem("wserror_" + tlid,errorct);
+			if(errorct<3){
+				reconnector(tlid,TLtype,acct_id,"","error");
+			}
 		}
 	};
 	websocketLocal[wslid].onclose = function() {
@@ -209,7 +213,11 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Closed');
 		}else{
-			reconnector(tlid,TLtype,acct_id,"","error");
+			var errorct=localStorage.getItem("wserror_" + tlid)*1+1;
+			localStorage.setItem("wserror_" + tlid,errorct);
+			if(errorct<3){
+				reconnector(tlid,TLtype,acct_id,"","error");
+			}
 		}
 	};
 	websocketHome[wshid].onerror = function(error) {
@@ -218,7 +226,11 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Error ' + error);
 		}else{
-			reconnector(tlid,TLtype,acct_id,"","error");
+			var errorct=localStorage.getItem("wserror_" + tlid)*1+1;
+			localStorage.setItem("wserror_" + tlid,errorct);
+			if(errorct<3){
+				reconnector(tlid,TLtype,acct_id,"","error");
+			}
 		}
 	};
 	websocketHome[wshid].onclose = function() {
@@ -227,7 +239,11 @@ function mixre(acct_id, tlid, TLtype, mute,delc,voice,mode) {
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Closed');
 		}else{
-			reconnector(tlid,TLtype,acct_id,"","error");
+			var errorct=localStorage.getItem("wserror_" + tlid)*1+1;
+			localStorage.setItem("wserror_" + tlid,errorct);
+			if(errorct<3){
+				reconnector(tlid,TLtype,acct_id,"","error");
+			}
 		}
 		
 	};

--- a/app/js/tl/tl.js
+++ b/app/js/tl/tl.js
@@ -801,7 +801,7 @@ function reconnector(tlid,type,acct_id,data,mode){
 		}
 		var wssh=localStorage.getItem("wssH_" + tlid);
 		websocketHome[wssh].close();
-		var wssh=localStorage.getItem("wssL_" + tlid);
+		var wssl=localStorage.getItem("wssL_" + tlid);
 		websocketLocal[wssl].close();
 		mixre(acct_id, tlid, type, mute,"",voice,mode);
 	}else if(type=="notf"){

--- a/app/js/tl/tl.js
+++ b/app/js/tl/tl.js
@@ -788,7 +788,7 @@ function strAliveInt(){
 }
 function reconnector(tlid,type,acct_id,data,mode){
 	console.log("Reconnector:"+mode)
-	if(type=="mix" || type=="plus"){
+	if(type=="mix" || type=="integrated" || type=="plus"){
 		if(localStorage.getItem("voice_" + tlid)){
 			var voice=true;
 		}else{

--- a/app/js/tl/tl.js
+++ b/app/js/tl/tl.js
@@ -337,8 +337,8 @@ function reload(type, cc, acct_id, tlid, data, mute, delc, voice, mode) {
 		return false;
 	};
 	websocket[wsid].onclose = function() {
-		console.error("Closing");
-		console.error(tlid);
+		console.log("Closing");
+		console.log(tlid);
 		if(mode=="error"){
 			$("#notice_icon_" + tlid).addClass("red-text");
 			todo('WebSocket Closed');


### PR DESCRIPTION
統合TLでストリーミングを再接続できない不具合を修正

- `integrated` type を `connector` 関数で扱えるように修正
- integrated の websocket にも `onerror` `onclose` にエラーカウンターを用意して不要な接続をなくす
- 閉じるだけでエラーログを吐くのはおかしいのでログレベルを変更	