### PR TITLE
Fix: cannot sort column if using some kind of TL

### DIFF
--- a/app/js/tl/tl.js
+++ b/app/js/tl/tl.js
@@ -851,7 +851,7 @@ function cap(type, data, acct_id) {
 	} else if (type == 'bookmark') {
 		var response = 'Bookmarks'
 	} else if (type == 'utl') {
-		var response = 'User TL(' + data.acct + ')'
+		var response = 'User TL(' + escapeHTML(data.acct) + ')'
 	}
 	return response
 }

--- a/app/js/ui/sort.js
+++ b/app/js/ui/sort.js
@@ -33,7 +33,7 @@ function sortLoad () {
 			var acctdata = user + "@" + domain;
 		}
 
-		var html = '<li class="drag-content" data-id="' + key + '" data-flag="' + flag + '"' + insert + '><div class="sorticon"><i class="material-icons">' + icon(acct.type) + '</i></div><div class="sorttitle">' + cap(acct.type, escapeHTML(acct.data), acct.domain) + '</div><div class="sortaction"><a onclick="goColumn(' + key +
+		var html = '<li class="drag-content" data-id="' + key + '" data-flag="' + flag + '"' + insert + '><div class="sorticon"><i class="material-icons">' + icon(acct.type) + '</i></div><div class="sorttitle">' + cap(acct.type, acct.data, acct.domain) + '</div><div class="sortaction"><a onclick="goColumn(' + key +
 			')" class="setting nex"><i class="material-icons waves-effect nex" title="' + lang.lang_sort_gothis + '">forward</i></a> <a onclick="removeColumn(' + key +
 			')" class="setting nex"><i class="material-icons waves-effect nex" title="このカラムを削除">cancel</i></a></div><div class="sortacct">' + acctdata + '</div></li>';
 		$("#sort").append(html);


### PR DESCRIPTION
If using some kind of TL, cannot sort column and looks no different after removing column.

TL固有の設定をdataにオブジェクトとして保有しているカラム(連合TL、タグTL、UserTL)がある時
`sortList()` 内でdataオブジェクトをそのまま文字列用の関数escapeHTMLに突っ込んでエラーで落ちるため

* 該当するカラム以降が並び替え画面に表示されず、表示されているカラムもドラッグで動かせない(並び替え出来ない)
* カラムを消してもF5しないと見た目に反映されない

のを直した