### PR TITLE
Fix: can break column data when deleting account

### DIFF
--- a/app/js/login/manager.js
+++ b/app/js/login/manager.js
@@ -244,16 +244,16 @@ function multiDel(target) {
 			var oldcols = JSON.parse(col)
 			var newcols = []
 			Object.keys(oldcols).forEach(function(key) {
-				var nk = key - 1
 				var oldcol = oldcols[key]
-				if (target < oldcol.domain) {
-					var newdom = oldcol.domain - 1
+				var olddom = oldcol.domain
+				if (olddom !== '' && !isNaN(olddom) && target < olddom) {
+					var newdom = olddom - 1
 				} else {
-					var newdom = oldcol.domain
+					var newdom = olddom
 				}
 				var type = oldcol.type
 				//消した垢のコラムじゃないときコピー
-				if (target != oldcol.domain) {
+				if (olddom === '' || target != olddom) {
 					var add = {
 						domain: newdom,
 						type: type

--- a/app/js/login/manager.js
+++ b/app/js/login/manager.js
@@ -251,13 +251,11 @@ function multiDel(target) {
 				} else {
 					var newdom = olddom
 				}
-				var type = oldcol.type
 				//消した垢のコラムじゃないときコピー
 				if (olddom === '' || target != olddom) {
-					var add = {
-						domain: newdom,
-						type: type
-					}
+					var add = oldcol
+					add.domain = newdom
+					if (add.left_fold) add.left_fold = false
 					newcols.push(add)
 				}
 			})


### PR DESCRIPTION
アカウント削除中のカラム整理で
* カラムのdataが保持されないためタグTLやユーザーTLが壊れ、そのTLを使っていた場合エラーでTL構築が止まることにより一部UIが表示されなくなる
* domainにアカウント番号でなくドメイン名が入るGlance TLが壊れ、空文字列が入るTwitterカラムが消える可能性がある

のを直した

(とりあえずleft_fold以外の全属性を保持するようにしてますが不都合あればそちらで修正いただくか教えてください)