### PR TITLE
Style correction when account notation is long at Toot.

### DIFF
--- a/app/css/tl.css
+++ b/app/css/tl.css
@@ -780,6 +780,11 @@ p:not(:last-child) {
 .dropdown-content li {
 	padding-top: 0.4rem;
 }
+.dropdown-content li > a, .dropdown-content li > span {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
 .fa-2x > .emoji-img {
 	width: 2.3rem !important;
 	height: 2.3rem !important;


### PR DESCRIPTION
## 概要

 Toot時のアカウント選択ドロップダウン内に表示される文字列が多い場合、
レイアウト崩れが発生していたので修正しました。

## Before

![image](https://user-images.githubusercontent.com/6540072/139525514-f9e1f975-a9f0-4739-9be0-208fbd818d86.png)


## After

![image](https://user-images.githubusercontent.com/6540072/139525522-5c327de8-1040-4a40-afba-2f5723e18ee4.png)
