### PR TITLE
Fix:アンケート投稿モードから復帰する際に投稿フォームの横幅が元に戻らない

### DIFF
--- a/app/js/tl/poll.ts
+++ b/app/js/tl/poll.ts
@@ -19,7 +19,7 @@ export function pollToggle() {
 		$('#right-side').hide()
 		$('#left-side').css('width', '100%')
 		$('#right-side').css('width', '300px')
-		$('#post-box').css('width', width + 'px')
+		$('#post-box').css('width', widthStr + 'px')
 		$('#emoji').addClass('hide')
 		$('#draft').addClass('hide')
 		$('#poll').addClass('hide')


### PR DESCRIPTION
投稿フォームをアンケート投稿モードにすると投稿フォームの横幅が広がるが、アンケート投稿モードを解除しても元に戻らない