### PR TITLE
実況モード強化

### DIFF
--- a/app/js/common/keyshortcut.ts
+++ b/app/js/common/keyshortcut.ts
@@ -50,6 +50,24 @@ export function initKeyboard() {
 				}
 			}
 		}
+		//Ctrl+Alt+Enter:実況なし投稿
+		if (e.metaKey || (e.ctrlKey && wv)) {
+			if (e.altKey) {
+				if (e.keyCode === 13) {
+					post(undefined,undefined,true)
+					return false
+				}
+			}
+		}
+		//Ctrl+Alt+C:全消し（実況タグセットなし）
+		if (e.metaKey || (e.ctrlKey && wv)) {
+			if (e.altKey) {
+				if (e.keyCode === 67) {
+					clear(true)
+					return false
+				}
+			}
+		}
 		//Ctrl+Enter:投稿
 		if (e.metaKey || (e.ctrlKey && wv)) {
 			if (e.keyCode === 13) {

--- a/app/js/post/post.ts
+++ b/app/js/post/post.ts
@@ -75,11 +75,9 @@ export async function post(postVis?: IVis, dry?: boolean, tagClear?: boolean ) {
 	if (editTarget) start = start + `/${editTarget}`
 	const reply = $('#reply').val()
 	const stable = JSON.parse(localStorage.getItem('stable') || '[]')
-	for ( const tag of stable){
-		if ( tagClear ){
-			do {
-				str = str.replace(`#${tag}`,'')
-			} while( str.match(tag) )
+	for (const tag of stable){
+		if (tagClear){
+			str = str.replace(new RegExp(`(\\s#${tag}\\s)`, 'g'), ' ').replace(new RegExp(`(^#${tag}\\s|\\s#${tag}$|^#${tag}$)`, 'g'), '')
 		} else {
 			if (!str.match(tag)) str = `${str} #${tag}`
 		}
@@ -192,11 +190,8 @@ export function clear(clearTags?: boolean) {
 	$('#textarea').val('')
 	$('#ideKey').val('')
 	const stable = JSON.parse(localStorage.getItem('stable') || '[]')
-	if ( !clearTags && stable ) {
-		let tags = ''
-		for ( const tag of stable ){
-			tags = tags + '#' + tag + ' '
-		}
+	if (!clearTags && stable.length) {
+		const tags = `#${stable.join(' #')} `
 		$('#textarea').val(tags)
 	}
 	$('#textarea').attr('placeholder', lang.lang_toot)

--- a/app/js/post/post.ts
+++ b/app/js/post/post.ts
@@ -25,7 +25,7 @@ export function sec() {
 	}
 	post(mode)
 }
-export async function post(postVis?: IVis, dry?: boolean, tagRemove?: boolean ) {
+export async function post(postVis?: IVis, dry?: boolean, tagClear?: boolean ) {
 	if (!navigator.onLine && !dry) {
 		draftToggle(true)
 		addToDraft()
@@ -76,7 +76,7 @@ export async function post(postVis?: IVis, dry?: boolean, tagRemove?: boolean ) 
 	const reply = $('#reply').val()
 	const stable = JSON.parse(localStorage.getItem('stable') || '[]')
 	for ( const tag of stable){
-		if ( tagRemove ){
+		if ( tagClear ){
 			do {
 				str = str.replace(`#${tag}`,'')
 			} while( str.match(tag) )

--- a/app/js/post/post.ts
+++ b/app/js/post/post.ts
@@ -25,7 +25,7 @@ export function sec() {
 	}
 	post(mode)
 }
-export async function post(postVis?: IVis, dry?: boolean) {
+export async function post(postVis?: IVis, dry?: boolean, tagRemove?: boolean ) {
 	if (!navigator.onLine && !dry) {
 		draftToggle(true)
 		addToDraft()
@@ -74,8 +74,16 @@ export async function post(postVis?: IVis, dry?: boolean) {
 	const editTarget = $('#tootmodal').attr('data-edit')
 	if (editTarget) start = start + `/${editTarget}`
 	const reply = $('#reply').val()
-	const stable = localStorage.getItem('stable')
-	if (stable && !str.match(stable)) str = `${str} #${stable}`
+	const stable = JSON.parse(localStorage.getItem('stable') || '[]')
+	for ( const tag of stable){
+		if ( tagRemove ){
+			do {
+				str = str.replace(`#${tag}`,'')
+			} while( str.match(tag) )
+		} else {
+			if (!str.match(tag)) str = `${str} #${tag}`
+		}
+	}
 	const toot: StatusTheDeskExtend = {
 		status: str,
 	}
@@ -179,12 +187,17 @@ export function expPostMode() {
 		})
 	}
 }
-//クリア(Shift+C)
-export function clear() {
+//クリア(Shift+C,Alt+Shift+C:Alt+Shift+Cの場合は実況タグをセットしない)
+export function clear(clearTags?: boolean) {
 	$('#textarea').val('')
 	$('#ideKey').val('')
-	if (localStorage.getItem('stable')) {
-		$('#textarea').val('#' + localStorage.getItem('stable') + ' ')
+	const stable = JSON.parse(localStorage.getItem('stable') || '[]')
+	if ( !clearTags && stable ) {
+		let tags = ''
+		for ( const tag of stable ){
+			tags = tags + '#' + tag + ' '
+		}
+		$('#textarea').val(tags)
 	}
 	$('#textarea').attr('placeholder', lang.lang_toot)
 	$('#reply').val('')

--- a/app/js/tl/tag.ts
+++ b/app/js/tl/tag.ts
@@ -70,9 +70,15 @@ function tagPin(tag: string) {
 export function tagRemove(key: number) {
 	const tags = localStorage.getItem('tag') || '[]'
 	const obj = JSON.parse(tags)
-	const nowPT = localStorage.getItem('stable')
-	if ( nowPT === obj[key] ) {
-		localStorage.removeItem('stable')
+	let pt = localStorage.getItem('stable') || '[]'
+	let nowPT = JSON.parse(pt)
+	for ( const PTag of nowPT ){
+		if ( PTag === obj[key] ) {
+			nowPT.splice(nowPT.indexOf(obj[key]),1)
+			localStorage.setItem('stable',JSON.stringify(nowPT))
+			toast({ html: PTag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })
+			break
+		}
 	}
 	obj.splice(key, 1)
 	const json = JSON.stringify(obj)
@@ -84,12 +90,12 @@ export function favTag() {
 	const tagArr = localStorage.getItem('tag') || '[]'
 	const obj = JSON.parse(tagArr)
 	let tags = ''
-	const nowPT = localStorage.getItem('stable')
+	const nowPT = JSON.parse(localStorage.getItem('stable')|| '[]')
 	let key = 0
 	for (const tagRaw of obj) {
 		let ptt = lang.lang_tags_unrealtime
 		let nowon = `(${lang.lang_tags_realtime})`
-		if (nowPT !== tagRaw) {
+		if (!nowPT.includes(tagRaw)) {
 			ptt = lang.lang_tags_realtime
 			nowon = ''
 		}
@@ -125,12 +131,14 @@ export function tagTL(a: IColumnType, b: string, d: string) {
 }
 export function autoToot(tag: string) {
 	tag = escapeHTML(tag)
-	const nowPT = localStorage.getItem('stable')
-	if (nowPT === tag) {
-		localStorage.removeItem('stable')
-		toast({ html: lang.lang_tags_unrealtime, displayLength: 3000 })
+	const nowPT = JSON.parse(localStorage.getItem('stable') || '[]')
+	if ( nowPT.includes(tag) ) {
+		nowPT.splice(nowPT.indexOf(tag),1)
+		localStorage.setItem('stable', JSON.stringify(nowPT))
+		toast({ html: tag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })
 	} else {
-		localStorage.setItem('stable', tag)
+		nowPT.push(tag)
+		localStorage.setItem('stable', JSON.stringify(nowPT))
 		toast({
 			html: lang.lang_tags_tagwarn.replace('{{tag}}', tag).replace('{{tag}}', tag),
 			displayLength: 3000,

--- a/app/js/tl/tag.ts
+++ b/app/js/tl/tag.ts
@@ -2,7 +2,7 @@ import lang from '../common/lang'
 import { columnReload, tl } from './tl'
 import { brInsert } from '../post/emoji'
 import { escapeHTML } from '../platform/first'
-import { toast } from '../common/declareM'
+import { characterCounterInit, toast } from '../common/declareM'
 import api from '../common/fetch'
 import { getColumn, setColumn } from '../common/storage'
 import { IColumnData, IColumnTag, IColumnType } from '../../interfaces/Storage'
@@ -72,8 +72,14 @@ export function tagRemove(key: number) {
 	const obj = JSON.parse(tags)
 	let pt = localStorage.getItem('stable') || '[]'
 	let nowPT = JSON.parse(pt)
+	let str = $('#textarea').val() as string
 	for ( const PTag of nowPT ){
 		if ( PTag === obj[key] ) {
+			do {
+				str = str.replace(`#${PTag}`,'')
+			} while( str.match(PTag) )
+			$('#textarea').val(str)
+			characterCounterInit($('#textarea'))
 			nowPT.splice(nowPT.indexOf(obj[key]),1)
 			localStorage.setItem('stable',JSON.stringify(nowPT))
 			toast({ html: PTag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })
@@ -133,6 +139,12 @@ export function autoToot(tag: string) {
 	tag = escapeHTML(tag)
 	const nowPT = JSON.parse(localStorage.getItem('stable') || '[]')
 	if ( nowPT.includes(tag) ) {
+		let str = $('#textarea').val() as string
+		do {
+			str = str.replace(`#${tag}`,'')
+		} while( str.match(tag) )
+		$('#textarea').val(str)
+		characterCounterInit($('#textarea'))
 		nowPT.splice(nowPT.indexOf(tag),1)
 		localStorage.setItem('stable', JSON.stringify(nowPT))
 		toast({ html: tag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })

--- a/app/js/tl/tag.ts
+++ b/app/js/tl/tag.ts
@@ -70,18 +70,16 @@ function tagPin(tag: string) {
 export function tagRemove(key: number) {
 	const tags = localStorage.getItem('tag') || '[]'
 	const obj = JSON.parse(tags)
-	let pt = localStorage.getItem('stable') || '[]'
-	let nowPT = JSON.parse(pt)
-	let str = $('#textarea').val() as string
-	for ( const PTag of nowPT ){
-		if ( PTag === obj[key] ) {
-			do {
-				str = str.replace(`#${PTag}`,'')
-			} while( str.match(PTag) )
+	const pt = localStorage.getItem('stable') || '[]'
+	const nowPT = JSON.parse(pt)
+	let str = $('#textarea').val()?.toString() || ''
+	for (const PTag of nowPT) {
+		if (PTag === obj[key]) {
+			str = str.replace(new RegExp(`(\\s#${PTag}\\s)`, 'g'), ' ').replace(new RegExp(`(^#${PTag}\\s|\\s#${PTag}$|^#${PTag}$)`, 'g'), '')
 			$('#textarea').val(str)
 			characterCounterInit($('#textarea'))
-			nowPT.splice(nowPT.indexOf(obj[key]),1)
-			localStorage.setItem('stable',JSON.stringify(nowPT))
+			nowPT.splice(nowPT.indexOf(obj[key]), 1)
+			localStorage.setItem('stable', JSON.stringify(nowPT))
 			toast({ html: PTag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })
 			break
 		}
@@ -96,7 +94,7 @@ export function favTag() {
 	const tagArr = localStorage.getItem('tag') || '[]'
 	const obj = JSON.parse(tagArr)
 	let tags = ''
-	const nowPT = JSON.parse(localStorage.getItem('stable')|| '[]')
+	const nowPT = JSON.parse(localStorage.getItem('stable') || '[]')
 	let key = 0
 	for (const tagRaw of obj) {
 		let ptt = lang.lang_tags_unrealtime
@@ -138,14 +136,12 @@ export function tagTL(a: IColumnType, b: string, d: string) {
 export function autoToot(tag: string) {
 	tag = escapeHTML(tag)
 	const nowPT = JSON.parse(localStorage.getItem('stable') || '[]')
-	if ( nowPT.includes(tag) ) {
-		let str = $('#textarea').val() as string
-		do {
-			str = str.replace(`#${tag}`,'')
-		} while( str.match(tag) )
+	if (nowPT.includes(tag)) {
+		let str = $('#textarea').val()?.toString() || ''
+		str = str.replace(new RegExp(`(\\s#${tag}\\s)`, 'g'), ' ').replace(new RegExp(`(^#${tag}\\s|\\s#${tag}$|^#${tag}$)`, 'g'), '')
 		$('#textarea').val(str)
 		characterCounterInit($('#textarea'))
-		nowPT.splice(nowPT.indexOf(tag),1)
+		nowPT.splice(nowPT.indexOf(tag), 1)
 		localStorage.setItem('stable', JSON.stringify(nowPT))
 		toast({ html: tag + ' ' + lang.lang_tags_unrealtime, displayLength: 3000 })
 	} else {

--- a/app/js/tl/tag.ts
+++ b/app/js/tl/tag.ts
@@ -70,6 +70,10 @@ function tagPin(tag: string) {
 export function tagRemove(key: number) {
 	const tags = localStorage.getItem('tag') || '[]'
 	const obj = JSON.parse(tags)
+	const nowPT = localStorage.getItem('stable')
+	if ( nowPT === obj[key] ) {
+		localStorage.removeItem('stable')
+	}
 	obj.splice(key, 1)
 	const json = JSON.stringify(obj)
 	localStorage.setItem('tag', json)


### PR DESCRIPTION
実況モードの強化。以下変更点
- Fix:実況モード中のタグを削除しても実況モードが解除されない
- 複数タグを個別に実況モードセット/解除できるように
- 実況モード解除した際にタグをtoast表示、入力中の文章から対象のタグ除去
- Ctrl+Alt+Enterで一時的に実況モードを無効にして投稿する（付加されている実況モード中のタグも除去する）
- Ctrl+Alt+Cで実況中タグをセットせずに投稿フォームのクリアのみ行う