### PR TITLE
Fix:画像付き投稿を編集しようとすると添付されている画像が欠落する

### DIFF
--- a/app/js/post/img.ts
+++ b/app/js/post/img.ts
@@ -265,7 +265,7 @@ export function pwaImgSelect() {
 }
 export async function deleteImage(key: string) {
 	const result = await Swal.fire({
-		title: lang.lang_postimg_delete,
+		title: lang.lang_postimg_delConfirm,
 		icon: 'warning',
 		showCancelButton: true,
 		confirmButtonText: lang.lang_yesno,

--- a/app/js/post/status.ts
+++ b/app/js/post/status.ts
@@ -342,17 +342,26 @@ export async function redraft(id: string, acctId: string) {
 }
 // edit
 export async function editToot(id: string, acctId: string) {
-	show()
 	const domain = localStorage.getItem(`domain_${acctId}`)
 	const at = localStorage.getItem(`acct_${acctId}_at`)
-	const start = `https://${domain}/api/v1/statuses/${id}`
-	const json = await api(start, {
+	const sourceStart = `https://${domain}/api/v1/statuses/${id}/source`
+	const sourceJson = await api(sourceStart, {
 		method: 'get',
 		headers: {
 			'Content-Type': 'application/json',
 			Authorization: 'Bearer ' + at,
 		},
 	})
+	const { text } = sourceJson
+	const start = `https://${domain}/api/v1/statuses/${id}`
+	const json = await api<Toot>(start, {
+		method: 'get',
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: 'Bearer ' + at,
+		},
+	})
+	json.text = text
 	draftToPost(json, acctId, id)
 }
 
@@ -369,9 +378,7 @@ export function draftToPost(json: Toot, acctId: string, id?: string) {
 		for (let i = 0; i <= 4; i++) {
 			if (!json.media_attachments[i]) break
 			media_ids.push(json.media_attachments[i].id)
-			//動かないのでひとまずコメントアウト・・・したいけどうまくいかないので物理的に消す
-			//$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;" data-acct="${acctId}" data-media="${json.media_attachments[i].id}" oncontextmenu="deleteImage('${json.media_attachments[i].id}')" onclick="altImage('${acctId}','${json.media_attachments[i].id}')" title="${lang.lang_postimg_delete}">`)
-			$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;" data-acct="${acctId}" data-media="${json.media_attachments[i].id}" title="${json.media_attachments[i].description}">`)
+			$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;" data-acct="${acctId}" data-media="${json.media_attachments[i].id}" oncontextmenu="deleteImage('${json.media_attachments[i].id}')" title="${lang.lang_postimg_delete}">`)
 		}
 	}
 	const visMode = json.visibility

--- a/app/js/post/status.ts
+++ b/app/js/post/status.ts
@@ -345,7 +345,7 @@ export async function editToot(id: string, acctId: string) {
 	show()
 	const domain = localStorage.getItem(`domain_${acctId}`)
 	const at = localStorage.getItem(`acct_${acctId}_at`)
-	const start = `https://${domain}/api/v1/statuses/${id}/source`
+	const start = `https://${domain}/api/v1/statuses/${id}`
 	const json = await api(start, {
 		method: 'get',
 		headers: {
@@ -369,7 +369,9 @@ export function draftToPost(json: Toot, acctId: string, id?: string) {
 		for (let i = 0; i <= 4; i++) {
 			if (!json.media_attachments[i]) break
 			media_ids.push(json.media_attachments[i].id)
-			$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;">`)
+			//動かないのでひとまずコメントアウト・・・したいけどうまくいかないので物理的に消す
+			//$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;" data-acct="${acctId}" data-media="${json.media_attachments[i].id}" oncontextmenu="deleteImage('${json.media_attachments[i].id}')" onclick="altImage('${acctId}','${json.media_attachments[i].id}')" title="${lang.lang_postimg_delete}">`)
+			$('#preview').append(`<img src="${json.media_attachments[i].preview_url}" style="width:50px; max-height:100px;" data-acct="${acctId}" data-media="${json.media_attachments[i].id}" title="${json.media_attachments[i].description}">`)
 		}
 	}
 	const visMode = json.visibility
@@ -378,7 +380,7 @@ export function draftToPost(json: Toot, acctId: string, id?: string) {
 	$('#media').val(medias)
 	localStorage.setItem('nohide', 'true')
 	show()
-	const html = json.text || json.content
+	const html = json.text || json.content.replace(/(<([^>]+)>)/gi, '')
 	$('#textarea').val(html)
 	if (json.spoiler_text) {
 		cw(true)

--- a/app/js/post/status.ts
+++ b/app/js/post/status.ts
@@ -380,7 +380,7 @@ export function draftToPost(json: Toot, acctId: string, id?: string) {
 	$('#media').val(medias)
 	localStorage.setItem('nohide', 'true')
 	show()
-	const html = json.text || json.content.replace(/(<([^>]+)>)/gi, '')
+	const html = json.text || json.content.replace(/<br \/>/gi,'\r\n').replace(/(<([^>]+)>)/gi, '')
 	$('#textarea').val(html)
 	if (json.spoiler_text) {
 		cw(true)

--- a/app/view/make/language/en/main.json
+++ b/app/view/make/language/en/main.json
@@ -65,6 +65,7 @@
     "lang_postimg_delete": "Click to add description, right-click to delete this",
     "lang_postimg_desc": "Description",
     "lang_postimg_leadContext": "right-click the thumbnail to delete this",
+    "lang_postimg_delConfirm": "Delete this image. Continue?",
     "lang_post_tagTL": "This toot does not contain a default tag. This toot will not be shown on Local TL. Continue?",
     "lang_post_tagVis": "This toot(not 'public' toot) is not shown on this tag's TL.",
     "lang_post_cwtitle": "Auto CW Alert",

--- a/app/view/make/language/ja-KS/main.json
+++ b/app/view/make/language/ja-KS/main.json
@@ -66,6 +66,7 @@
     "lang_postimg_leadContext": "画像を削除するんやったら右クリック",
     "lang_post_tagTL": "デフォルトタグ無いしこのまま投稿するとローカルには表示されへんで。",
     "lang_post_tagVis": "公開範囲が「公開」以外やったら、タグTLには出えへんで。(一部インスタンスを除く)",
+    "lang_postimg_delConfirm": "画像をほかしてええか？",
     "lang_post_cwtitle": "長文投稿の警告",
     "lang_post_cwtxt": "指定文字数、行数を超えるトゥートをしようとしてんねんけどどうする？CW付ける？\n自動CWのタイトル:",
     "lang_post_btn1": "キャンセル(投稿せえへん)",

--- a/app/view/make/language/ja/main.json
+++ b/app/view/make/language/ja/main.json
@@ -66,6 +66,7 @@
     "lang_postimg_desc": "説明",
     "lang_postimg_sync": "処理は同期的に行われます。最初にご確認ください→",
     "lang_postimg_leadContext": "画像を削除するためには右クリック",
+    "lang_postimg_delConfirm": "画像を削除します。よろしいですか？",
     "lang_post_tagTL": "デフォルトタグが挿入されていません。このまま投稿するとローカルには表示されません。",
     "lang_post_tagVis": "公開範囲が「公開」以外だと、タグTLに表示されません。(一部インスタンスを除く)",
     "lang_post_cwtitle": "長文投稿の警告",


### PR DESCRIPTION
画像のAlt text編集対応の下準備　現在編集時にaltの編集と画像削除はできません