### PR TITLE
Fix:ミュートするとブロックボタンが「ブロック解除」になりミュートボタン表示が変わらない

### DIFF
--- a/app/js/post/status.ts
+++ b/app/js/post/status.ts
@@ -257,9 +257,9 @@ export async function block(acctId: string) {
 //ミュート
 export async function muteDo(acctId: string) {
 	if (!acctId) acctId = $('#his-data').attr('use-acct') || ''
-	const isBlock = $('#his-data').hasClass('muting')
-	const flag = isBlock ? 'unmute' : 'mute'
-	const txt = isBlock ? lang.lang_status_unmute : lang.lang_status_mute
+	const isMute = $('#his-data').hasClass('muting')
+	const flag = isMute ? 'unmute' : 'mute'
+	const txt = isMute ? lang.lang_status_unmute : lang.lang_status_mute
 	const result = await Swal.fire({
 		title: txt,
 		text: '',
@@ -291,18 +291,32 @@ export async function muteDo(acctId: string) {
 			},
 			body: q,
 		})
-		if ($('#his-data').hasClass('blocking')) {
-			$('#his-data').removeClass('blocking')
-			$('#his-block-btn-text').text(lang.lang_status_block)
+		if ($('#his-data').hasClass('muting')) {
+			$('#his-data').removeClass('muting')
+			$('#his-mute-btn-text').text(lang.lang_status_mute)
+			$('#his-mute-btn').text(lang.lang_status_mute)
 		} else {
-			$('#his-data').addClass('blocking')
-			$('#his-block-btn-text').text(lang.lang_status_unblock)
+			$('#his-data').addClass('muting')
+			$('#his-mute-btn-text').text(lang.lang_status_unmute)
+			$('#his-mute-btn').text(lang.lang_status_unmute)
 		}
+		muteMenu()
 	}
 }
 export function muteMenu() {
 	$('#muteDuration').toggleClass('hide')
-	!$('#muteDuration').hasClass('hide') ? $('#his-des').css('max-height', '0px') : $('#his-des').css('max-height', '196px')
+	if (!$('#muteDuration').hasClass('hide')){
+		$('#his-des').css('max-height', '0px') 
+	} else {
+		$('#his-des').css('max-height', '196px')
+	}
+	if (!$('#his-data').hasClass('muting')) {
+		$('#his-mute-btn-text').text(lang.lang_status_mute)
+		$('#his-mute-btn').text(lang.lang_status_mute)
+	} else {
+		$('#his-mute-btn-text').text(lang.lang_status_unmute)
+		$('#his-mute-btn').text(lang.lang_status_unmute)
+	}
 }
 export function muteTime(day: number, hour: number, min: number) {
 	$('#days_mute').val(day)

--- a/app/js/userdata/showOnTL.ts
+++ b/app/js/userdata/showOnTL.ts
@@ -244,8 +244,10 @@ async function relations(user: string, acctId: string) {
 	if (json.muting) {
 		$('#his-data').addClass('muting')
 		$('#his-mute-btn-text').text(lang.lang_status_unmute)
+		$('#his-mute-btn').text(lang.lang_status_unmute)
 	} else {
 		$('#his-mute-btn-text').text(lang.lang_status_mute)
+		$('#his-mute-btn').text(lang.lang_status_mute)
 	}
 	if (json.muting_notifications) {
 		$('#his-data').addClass('mutingNotf')
@@ -332,6 +334,7 @@ function reset() {
 	$('#his-block-btn-text').text(lang.lang_status_block)
 	$('#his-notf-btn').text(lang.lang_showontl_notf + lang.lang_status_mute)
 	$('#his-domain-btn').text(lang.lang_showontl_domain + lang.lang_status_block)
+	$('#muteDuration').addClass('hide')
 	$('#his-relation').text('')
 	$('.cont-series').html('')
 	$('#domainblock').val('')


### PR DESCRIPTION
ミュートするとブロックボタンの表示が「ブロック解除」に変わるバグ修正
追記：ミュートメニューを表示させたままユーザー情報表示を閉じると、次回ユーザー情報を開いた際にミュートメニューが開いたままになるバグを一緒に修正しています